### PR TITLE
use kombu's ensure_connection

### DIFF
--- a/oslo/messaging/_drivers/impl_rabbit.py
+++ b/oslo/messaging/_drivers/impl_rabbit.py
@@ -646,7 +646,8 @@ class Connection(object):
         self._heartbeat_support_log_emitted = False
 
         # NOTE(sileht): just ensure the connection is setuped at startup
-        self.ensure_connection()
+        with self._connection_lock:
+            self.ensure_connection()
 
         # NOTE(sileht): if purpose is PURPOSE_LISTEN
         # the consume code does the heartbeat stuff
@@ -713,9 +714,56 @@ class Connection(object):
             return ssl_params or True
         return False
 
-    def ensure_connection(self):
-        self.ensure(error_callback=None,
-                    method=lambda: True)
+    def ensure_connection(self, retry=None, callback=None):
+        # This method should be invoked in a lock.
+        if retry is None:
+            retry = self.max_retries
+        if retry is None or retry < 0:
+            retry = None
+
+        def on_error(exc, interval):
+            self.reconnect_errback(exc, interval)
+
+        if not self.connection.connected:
+            self.connection.ensure_connection(
+                errback=on_error,
+                max_retries=retry,
+                interval_start=self.interval_start or 1,
+                interval_step=self.interval_stepping,
+                interval_max=self.interval_max,
+                callback=callback
+            )
+
+    def reconnect_errback(self, exc, interval):
+
+        interval = (self.conf.kombu_reconnect_delay + interval
+                    if self.conf.kombu_reconnect_delay > 0 else interval)
+
+        info = {'hostname': self.connection.hostname,
+                'port': self.connection.port,
+                'err_str': exc, 'sleep_time': interval}
+
+        if 'Socket closed' in six.text_type(exc):
+            LOG.error(_('AMQP server %(hostname)s:%(port)s closed'
+                        ' the connection. Check login credentials:'
+                        ' %(err_str)s'), info)
+        else:
+            LOG.error(_('AMQP server on %(hostname)s:%(port)s is '
+                        'unreachable: %(err_str)s. Trying again in '
+                        '%(sleep_time)d seconds.'), info)
+
+        # XXX(nic): when reconnecting to a RabbitMQ cluster
+        # with mirrored queues in use, the attempt to release the
+        # connection can hang "indefinitely" somewhere deep down
+        # in Kombu.  Blocking the thread for a bit prior to
+        # release seems to kludge around the problem where it is
+        # otherwise reproduceable.
+        # TODO(sileht): Check if this is useful since we
+        # use kombu for HA connection, the interval_step
+        # should sufficient, because the underlying kombu transport
+        # connection object freed.
+        if self.conf.kombu_reconnect_delay > 0:
+            time.sleep(self.conf.kombu_reconnect_delay)
 
     def ensure(self, error_callback, method, retry=None,
                timeout_is_error=True):
@@ -735,35 +783,7 @@ class Connection(object):
 
         def on_error(exc, interval):
             error_callback and error_callback(exc)
-
-            interval = (self.conf.kombu_reconnect_delay + interval
-                        if self.conf.kombu_reconnect_delay > 0 else interval)
-
-            info = {'hostname': self.connection.hostname,
-                    'port': self.connection.port,
-                    'err_str': exc, 'sleep_time': interval}
-
-            if 'Socket closed' in six.text_type(exc):
-                LOG.error(_('AMQP server %(hostname)s:%(port)s closed'
-                            ' the connection. Check login credentials:'
-                            ' %(err_str)s'), info)
-            else:
-                LOG.error(_('AMQP server on %(hostname)s:%(port)s is '
-                            'unreachable: %(err_str)s. Trying again in '
-                            '%(sleep_time)d seconds.'), info)
-
-            # XXX(nic): when reconnecting to a RabbitMQ cluster
-            # with mirrored queues in use, the attempt to release the
-            # connection can hang "indefinitely" somewhere deep down
-            # in Kombu.  Blocking the thread for a bit prior to
-            # release seems to kludge around the problem where it is
-            # otherwise reproduceable.
-            # TODO(sileht): Check if this is useful since we
-            # use kombu for HA connection, the interval_step
-            # should sufficient, because the underlying kombu transport
-            # connection object freed.
-            if self.conf.kombu_reconnect_delay > 0:
-                time.sleep(self.conf.kombu_reconnect_delay)
+            self.reconnect_errback(exc, interval)
 
         def on_reconnection(new_channel):
             """Callback invoked when the kombu reconnects and creates


### PR DESCRIPTION
原来的 ensure_connection 完全起不到断线重连的作用：
1. 由于它传递的方法是 lambda: True，所以在 ensure 方法中的 autoretry 时将不会抛“连接已断”的错误，因为方法的调用过程中没有使用到连接，也就无从确认连接是否健康。
2. 如果 Connection.channel 被设置为 None，这时 autoretry 中会尝试新建一个 channel (代码参见/usr/lib/python2.7/site-packages/kombu/connection.py 中的 autoretry)再调用 lambda: True 方法。 然而如果连接已经断开的话， autoretry 中尝试新建一个 channel 的动作会直接触发一个 Nonetype 错误，最终重连也完全失败。 归根结底是，如果连接已断开的时候，不能使用 kombu 的autoretry 来进行重连，而应该使用 kombu 的 ensure_connection。

Signed-off-by: apporc appleorchard2000@gmail.com
