### PR TITLE
Don't reply when we known that client is gone

### DIFF
--- a/oslo/messaging/_drivers/amqp.py
+++ b/oslo/messaging/_drivers/amqp.py
@@ -275,3 +275,6 @@ def _add_unique_id(msg):
     unique_id = uuid.uuid4().hex
     msg.update({UNIQUE_ID: unique_id})
     LOG.debug('UNIQUE_ID is %s.', unique_id)
+
+class AMQPDestinationNotFound(Exception):
+    pass

--- a/oslo/messaging/_drivers/amqpdriver.py
+++ b/oslo/messaging/_drivers/amqpdriver.py
@@ -19,6 +19,8 @@ import logging
 import threading
 import uuid
 
+import cachetools
+
 from six import moves
 
 from oslo import messaging
@@ -31,7 +33,8 @@ LOG = logging.getLogger(__name__)
 
 class AMQPIncomingMessage(base.IncomingMessage):
 
-    def __init__(self, listener, ctxt, message, unique_id, msg_id, reply_q):
+    def __init__(self, listener, ctxt, message, unique_id, msg_id, reply_q,
+                 obsolete_reply_queues):
         super(AMQPIncomingMessage, self).__init__(listener, ctxt,
                                                   dict(message))
 
@@ -40,9 +43,14 @@ class AMQPIncomingMessage(base.IncomingMessage):
         self.reply_q = reply_q
         self.acknowledge_callback = message.acknowledge
         self.requeue_callback = message.requeue
+        self._obsolete_reply_queues = obsolete_reply_queues
 
     def _send_reply(self, conn, reply=None, failure=None,
                     ending=False, log_failure=True):
+        if (self.reply_q and
+            not self._obsolete_reply_queues.reply_q_valid(self.reply_q,
+                                                          self.msg_id)):
+            return
         if failure:
             failure = rpc_common.serialize_remote_exception(failure,
                                                             log_failure)
@@ -58,8 +66,15 @@ class AMQPIncomingMessage(base.IncomingMessage):
         # Otherwise use the msg_id for backward compatibility.
         if self.reply_q:
             msg['_msg_id'] = self.msg_id
-            conn.direct_send(self.reply_q, rpc_common.serialize_msg(msg))
+            try:
+                conn.direct_send(self.reply_q, rpc_common.serialize_msg(msg))
+            except rpc_amqp.AMQPDestinationNotFound:
+                self._obsolete_reply_queues.add(self.reply_q, self.msg_id)
         else:
+            # TODO(sileht): look at which version of oslo-incubator rpc
+            # send need this, but I guess this is older than icehouse
+            # if this is icehouse, we can drop this at M
+            # if this is havana, we can drop this now.
             conn.direct_send(self.msg_id, rpc_common.serialize_msg(msg))
 
     def reply(self, reply=None, failure=None, log_failure=True):
@@ -67,6 +82,13 @@ class AMQPIncomingMessage(base.IncomingMessage):
             # NOTE(Alexei_987) not sending reply, if msg_id is empty
             #    because reply should not be expected by caller side
             return
+
+        # NOTE(sileht): return without hold the a connection if possible
+        if (self.reply_q and
+            not self._obsolete_reply_queues.reply_q_valid(self.reply_q,
+                                                          self.msg_id)):
+            return
+
         with self.listener.driver._get_connection(
                 rpc_amqp.PURPOSE_SEND) as conn:
             self._send_reply(conn, reply, failure, log_failure=log_failure)
@@ -85,6 +107,50 @@ class AMQPIncomingMessage(base.IncomingMessage):
         # the end.
         self.requeue_callback()
 
+class ObsoleteReplyQueuesCache(object):
+    """Cache of reply queue id that doesn't exists anymore.
+
+    NOTE(sileht): In case of a broker restart/failover
+    a reply queue can be unreachable for short period
+    the IncomingMessage.send_reply will block for 60 seconds
+    in this case or until rabbit recovers.
+
+    But in case of the reply queue is unreachable because the
+    rpc client is really gone, we can have a ton of reply to send
+    waiting 60 seconds.
+    This leads to a starvation of connection of the pool
+    The rpc server take to much time to send reply, other rpc client will
+    raise TimeoutError because their don't receive their replies in time.
+
+    This object cache stores already known gone client to not wait 60 seconds
+    and hold a connection of the pool.
+    Keeping 200 last gone rpc client for 1 minute is enough
+    and doesn't hold to much memory.
+    """
+
+    SIZE = 200
+    TTL = 60
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._cache = cachetools.TTLCache(self.SIZE, self.TTL)
+
+    def reply_q_valid(self, reply_q, msg_id):
+        if reply_q in self._cache:
+            self._no_reply_log(reply_q, msg_id)
+            return False
+        return True
+
+    def add(self, reply_q, msg_id):
+        with self._lock:
+            self._cache.update({reply_q: msg_id})
+        self._no_reply_log(reply_q, msg_id)
+
+    def _no_reply_log(self, reply_q, msg_id):
+        LOG.warn(("%(reply_queue)s doesn't exists, drop reply to "
+                     "%(msg_id)s"), {'reply_queue': reply_q,
+                                     'msg_id': msg_id})
+
 
 class AMQPListener(base.Listener):
 
@@ -94,6 +160,7 @@ class AMQPListener(base.Listener):
         self.msg_id_cache = rpc_amqp._MsgIdCache()
         self.incoming = []
         self._stopped = threading.Event()
+        self._obsolete_reply_queues = ObsoleteReplyQueuesCache()
 
     def __call__(self, message):
         # FIXME(markmc): logging isn't driver specific
@@ -107,7 +174,8 @@ class AMQPListener(base.Listener):
                                                  message,
                                                  unique_id,
                                                  ctxt.msg_id,
-                                                 ctxt.reply_q))
+                                                 ctxt.reply_q,
+                                                 self._obsolete_reply_queues))
 
     def poll(self, timeout=None):
         while not self._stopped.is_set():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ stevedore>=1.0.0,<=1.3.0 # Apache-2.0
 
 # for jsonutils
 six>=1.7.0,<=1.9.0
+cachetools>=1.0.0 # MIT License
 
 # FIXME(markmc): remove this when the drivers no longer
 # import eventlet


### PR DESCRIPTION
In case of a broker restart/failover a reply queue can be unreachable for short period the IncomingMessage.send_reply will block for 60 seconds in this case or until rabbit recovers.
But in case of the reply queue is unreachable because the rpc client is really gone, we can have a ton of reply to send waiting 60 seconds.
This leads to a starvation of connection of the pool The rpc server take to much time to send reply, other rpc client will raise TimeoutError because their don't receive their replies in time.
This changes introduces an object cache that stores already known gone client to not wait 60 seconds and hold a connection of the pool Keeping 200 last gone rpc client for 1 minute is enough and doesn't hold to much memory.
This also don't raise anymore a frightening exception when we can't send reply to the rpc client. But just logging a info about missing exchange and a warning about unsend reply.

Related upstream commit: 286659a38be5db399d0b9f807fac7b980d6c0b7e
modified the log message format in direct_send function

Signed-off-by: blkart blkart.org@gmail.com
